### PR TITLE
[SPARK-189] Fixes to make it work on Windows

### DIFF
--- a/dcos_spark/spark_submit.py
+++ b/dcos_spark/spark_submit.py
@@ -240,15 +240,18 @@ def check_java_version(java_path):
 
 
 def check_java():
+    java_executable = 'java'
+    if util.is_windows_platform():
+        java_executable = java_executable + '.exe'
     # Check if JAVA is in the PATH
-    if which('java') is not None:
-        return check_java_version('java')
+    if which(java_executable) is not None:
+        return check_java_version(java_executable)
 
     # Check if JAVA_HOME is set and find java
     java_home = os.environ.get('JAVA_HOME')
 
     if java_home is not None:
-        java_path = os.path.join(java_home, "bin", "java")
+        java_path = os.path.join(java_home, "bin", java_executable)
         if os.path.isfile(java_path):
             return check_java_version(java_path)
 
@@ -313,7 +316,7 @@ def run(master, args, verbose, props=[]):
         return (None, process.returncode)
     else:
         if "{" in err:
-            lines = err.split(os.linesep)
+            lines = err.splitlines()
             jsonStr = ""
             startScan = False
             for l in lines:
@@ -336,7 +339,10 @@ def _get_spark_hdfs_url():
 
 
 def _get_command(master, args):
-    submit_file = spark_file(os.path.join('bin', 'spark-submit'))
+    spark_executable = 'spark-submit'
+    if util.is_windows_platform():
+        spark_executable = spark_executable + '.cmd'
+    submit_file = spark_file(os.path.join('bin', spark_executable))
 
     return [submit_file, "--deploy-mode", "cluster", "--master",
             "mesos://" + master] + args

--- a/dcos_spark/spark_submit.py
+++ b/dcos_spark/spark_submit.py
@@ -240,9 +240,7 @@ def check_java_version(java_path):
 
 
 def check_java():
-    java_executable = 'java'
-    if util.is_windows_platform():
-        java_executable = java_executable + '.exe'
+    java_executable = 'java.exe' if util.is_windows_platform() else 'java'
     # Check if JAVA is in the PATH
     if which(java_executable) is not None:
         return check_java_version(java_executable)
@@ -339,9 +337,8 @@ def _get_spark_hdfs_url():
 
 
 def _get_command(master, args):
-    spark_executable = 'spark-submit'
-    if util.is_windows_platform():
-        spark_executable = spark_executable + '.cmd'
+    spark_executable = 'spark-submit.cmd' if util.is_windows_platform() \
+                                          else 'spark-submit'
     submit_file = spark_file(os.path.join('bin', spark_executable))
 
     return [submit_file, "--deploy-mode", "cluster", "--master",


### PR DESCRIPTION
  - Fixed Java discovery 
    -  Look for `java.exe` on windows instead of `java`

  - Use `spark_submit.cmd` instead of `spark_submit`
    - `spark_submit` is a bash script which would not work on windows, hence use the windows cmd script 
 
- Use splitlines() instead of split(os.linesep)
    -  Response for spark_submit is of format : 
    <INFO level log lines>\r{\r\n  "action":
Notice that there is just a `\r` after the log lines and not `\r\n` `os.linesep` for windows is `\r\n` and hence it does not separate the lines as desired and the beginning of the JSON (`{`) gets separated as end of last log line instead of beginning of a new line. This leads to `l.startswith("{")` never to be true and we end up with an empty jsonSTR
splitlines() solves this issue.