### PR TITLE
Fix for python2 on Windows

### DIFF
--- a/dcos_spark/spark_submit.py
+++ b/dcos_spark/spark_submit.py
@@ -278,6 +278,9 @@ def run(master, args, verbose, props=[]):
 
     extra_env = {"SPARK_JAVA_OPTS": ' '.join(props)}
     env = dict(os.environ, **extra_env)
+    # On Windows python 2 complains about unicode in env
+    if util.is_windows_platform() and sys.version_info[0] < 3:
+        env = dict([str(key), str(value)] for key, value in env.iteritems())
     process = subprocess.Popen(
         command,
         env=env,


### PR DESCRIPTION
`TypeError: environment can only contain strings ` is encountered on Windows with python 2 while invoking `system.Popen` with `env`. Converted all key/values in the `dict` to `str` for python 2 and Windows. 